### PR TITLE
Fix: branch broke product

### DIFF
--- a/src/CZMQ-ZWSSock/zwshandshake.c
+++ b/src/CZMQ-ZWSSock/zwshandshake.c
@@ -330,6 +330,7 @@ zframe_t* zwshandshake_get_response(zwshandshake_t *self)
 	const char * magic_string = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 
 	char * key = zhash_lookup(self->header_fields, sec_websocket_key_name);
+	if (key == NULL) return NULL;
 
 	int len = strlen(key) + strlen(magic_string);
 


### PR DESCRIPTION
The intention of this branch was to validate that a header was advertised by the client. And based on this header check if we should continue. The previous code only implemented the rendering of this reply; but it was triggered at the wrong point of the code.

The problem at: https://github.com/zeromq/zwssock/compare/master...bliksemlabs:hotfix-ws-not-acceptable?expand=1#diff-8718e4daea83a6ad11d25d696e665b80L255

We can't return an error here at this point. Here we want to switch protocols. I think we must document this better.