### PR TITLE
Feature permessage compression

### DIFF
--- a/src/CZMQ-ZWSSock/Makefile
+++ b/src/CZMQ-ZWSSock/Makefile
@@ -3,9 +3,9 @@ SRCS = main.c  zwsdecoder.c  zwshandshake.c  zwssock.c
 CC = gcc
 DEBUG = -g
 MILITANT = -Werror
-CFLAGS= -std=gnu99  -Wall $(shell pkg-config --cflags libczmq) $(DEBUG) $(MILITANT)
+CFLAGS= -std=gnu99  -Wall $(shell pkg-config --cflags libczmq zlib) $(DEBUG) $(MILITANT)
 LDFLAGS = -Wall $(DEBUG)
-LIBS =  $(shell pkg-config --libs libczmq)
+LIBS =  $(shell pkg-config --libs libczmq zlib)
 
 DEPDIR=./deps
 OBJDIR=./objs

--- a/src/CZMQ-ZWSSock/zwsdecoder.c
+++ b/src/CZMQ-ZWSSock/zwsdecoder.c
@@ -75,7 +75,7 @@ void zwsdecoder_process_buffer(zwsdecoder_t *self, zframe_t* data)
 		case begin_payload:
 
 			self->payload_index = 0;
-			self->payload = zmalloc(sizeof(byte) * self->payload_length);
+			self->payload = zmalloc(sizeof(byte) * (self->payload_length + 4)); // +4 extra bytes in case we have to inflate it
 
 			// continue to payload
 		case payload:

--- a/src/CZMQ-ZWSSock/zwshandshake.h
+++ b/src/CZMQ-ZWSSock/zwshandshake.h
@@ -11,7 +11,7 @@ void zwshandshake_destroy(zwshandshake_t **self_p);
 
 bool zwshandshake_parse_request(zwshandshake_t *self, zframe_t* data);
 
-zframe_t* zwshandshake_get_response(zwshandshake_t *self);
+zframe_t* zwshandshake_get_response(zwshandshake_t *self, unsigned char *client_max_window_bits, unsigned char *server_max_window_bits);
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
This is my second version of the Websockets permessage-compression extension. I have implemented it because I thought that zwssock was literaly the most awesome thing I found a few weeks ago, and I build a  debugging tool for https://github.com/RoutingKit/RoutingKit/ on top of it. My problem was that GeoJSON is quite verbose, especially if it is used for routing through Europe. Content-Encoding: gzip helps a lot in the HTTP case, but considering I am using ZeroMQ in the backend, I wanted to have an end-to-end solution including compression to the client, without compressing the content itself.

This pull request goes step by step towards the final implementation. I would prefer some suggestions for https://github.com/zeromq/zwssock/compare/master...bliksemlabs:feature-permessage-compression#diff-8718e4daea83a6ad11d25d696e665b80R523